### PR TITLE
fix: Remove unnecessary numpy conversion causing TypeError

### DIFF
--- a/model/ALDI.py
+++ b/model/ALDI.py
@@ -112,7 +112,7 @@ class ALDI(BaseColdStartTrainer):
             #score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
             score[self.data.mapped_warm_item_idx] = torch.matmul(self.warm_user_emb[users], self.item_emb[self.data.mapped_warm_item_idx].transpose(0, 1))
             score[self.data.mapped_cold_item_idx] = torch.matmul(self.cold_user_emb[users], self.item_emb[self.data.mapped_cold_item_idx].transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class ALDI_Learner(nn.Module):

--- a/model/AMR.py
+++ b/model/AMR.py
@@ -77,7 +77,7 @@ class AMR(BaseColdStartTrainer):
             score2 = torch.matmul(self.user_emb_aux[users], self.item_emb_aux.transpose(0, 1))
             #score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
             score = score1 + score2
-            return score.cpu().numpy()
+            return score
 
 
 class AMR_Learner(nn.Module):

--- a/model/CCFCRec.py
+++ b/model/CCFCRec.py
@@ -112,7 +112,7 @@ class CCFCRec(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class CCFCRec_Learner(nn.Module):

--- a/model/CLCRec.py
+++ b/model/CLCRec.py
@@ -74,7 +74,7 @@ class CLCRec(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class CLCRec_Learner(nn.Module):

--- a/model/DUIF.py
+++ b/model/DUIF.py
@@ -63,7 +63,7 @@ class DUIF(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class DUIF_Encoder(nn.Module):

--- a/model/DeepMusic.py
+++ b/model/DeepMusic.py
@@ -86,7 +86,7 @@ class DeepMusic(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class DeepMusic_Encoder(nn.Module):

--- a/model/DropoutNet.py
+++ b/model/DropoutNet.py
@@ -74,7 +74,7 @@ class DropoutNet(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class DropoutNet_Learner(nn.Module):

--- a/model/GAR.py
+++ b/model/GAR.py
@@ -88,7 +88,7 @@ class GAR(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class GAR_Learner(nn.Module):

--- a/model/GoRec.py
+++ b/model/GoRec.py
@@ -103,7 +103,7 @@ class GoRec(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class GoRec_Learner(nn.Module):

--- a/model/Heater.py
+++ b/model/Heater.py
@@ -73,7 +73,7 @@ class Heater(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class Heater_Learner(nn.Module):

--- a/model/KNN.py
+++ b/model/KNN.py
@@ -108,4 +108,4 @@ class KNN(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score

--- a/model/LARA.py
+++ b/model/LARA.py
@@ -87,7 +87,7 @@ class LARA(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class LARA_Learner(nn.Module):

--- a/model/LightGCN.py
+++ b/model/LightGCN.py
@@ -63,7 +63,7 @@ class LightGCN(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class LGCN_Encoder(nn.Module):

--- a/model/MF.py
+++ b/model/MF.py
@@ -62,7 +62,7 @@ class MF(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class Matrix_Factorization(nn.Module):

--- a/model/MTPR.py
+++ b/model/MTPR.py
@@ -72,7 +72,7 @@ class MTPR(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class MTPR_Learner(nn.Module):

--- a/model/MetaEmbedding.py
+++ b/model/MetaEmbedding.py
@@ -100,7 +100,7 @@ class MetaEmbedding(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class MetaEmbedding_Learner(nn.Module):

--- a/model/NCL.py
+++ b/model/NCL.py
@@ -150,7 +150,7 @@ class NCL(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class LGCN_Encoder(nn.Module):

--- a/model/NGCF.py
+++ b/model/NGCF.py
@@ -65,7 +65,7 @@ class NGCF(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class NGCF_Encoder(nn.Module):

--- a/model/SimGCL.py
+++ b/model/SimGCL.py
@@ -76,7 +76,7 @@ class SimGCL(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class SimGCL_Encoder(nn.Module):

--- a/model/VBPR.py
+++ b/model/VBPR.py
@@ -76,7 +76,7 @@ class VBPR(BaseColdStartTrainer):
             score1 = torch.matmul(self.user_emb_main[users], self.item_emb_main.transpose(0, 1))
             score2 = torch.matmul(self.user_emb_aux[users], self.item_emb_aux.transpose(0, 1))
             score = score1 + score2
-            return score.cpu().numpy()
+            return score
 
 
 class VBPR_Learner(nn.Module):

--- a/model/XSimGCL.py
+++ b/model/XSimGCL.py
@@ -75,7 +75,7 @@ class XSimGCL(BaseColdStartTrainer):
             users = self.data.get_user_id_list(users)
             users = torch.tensor(users, device=self.device)
             score = torch.matmul(self.user_emb[users], self.item_emb.transpose(0, 1))
-            return score.cpu().numpy()
+            return score
 
 
 class XSimGCL_Encoder(nn.Module):


### PR DESCRIPTION
The model's prediction function was causing a `TypeError` in downstream operations like `torch.topk` because it incorrectly converted a Tensor to a NumPy array.

This is part of the work for #6 

This commit removes the unnecessary `.cpu().numpy()` call. The prediction function now returns the raw PyTorch tensor directly.

This change improves performance by avoiding GPU-to-CPU data transfer and keeps the data on-device for subsequent tensor computations.

💥 **BREAKING CHANGE**: Callers of the prediction function must now be updated to handle a PyTorch tensor as output instead of a NumPy array.