### PR TITLE
refactor: Simplify evaluation logic and remove numba dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ python >= 3.8.0
 torch >= 1.11.0
 faiss-gpu >= 1.7.3
 pandas >= 2.0.3
-numba >= 0.58.1 
 numpy >= 1.24.4
 scikit-learn >= 1.3.2
 pickle >= 0.7.5

--- a/util/operator.py
+++ b/util/operator.py
@@ -1,7 +1,5 @@
 from numpy.linalg import norm
 from math import sqrt, exp
-from numba import jit
-import heapq
 import torch
 
 
@@ -140,23 +138,3 @@ def sigmoid(val):
 
 def denormalize(vec, max_val, min_val):
     return min_val + (vec - 0.01) * (max_val - min_val)
-
-
-@jit(nopython=True)
-def find_k_largest(K, candidates):
-    n_candidates = []
-    for iid, score in enumerate(candidates[:K]):
-        n_candidates.append((score, iid))
-    heapq.heapify(n_candidates)
-    for iid, score in enumerate(candidates[K:]):
-        if score > n_candidates[0][0]:
-            heapq.heapreplace(n_candidates, (score, iid + K))
-    n_candidates.sort(key=lambda d: d[0], reverse=True)
-    ids = [item[1] for item in n_candidates]
-    k_largest_scores = [item[0] for item in n_candidates]
-    return ids, k_largest_scores
-
-
-def batch_find_k_largest(K, candidates):
-    scores, indices = torch.topk(candidates, K, dim=1, largest=True, sorted=True)
-    return indices.cpu().numpy(), scores.cpu().numpy()


### PR DESCRIPTION
## Summary

We finally got rid of the `numba` library and deprecated all single-user evaluation methods! 👏

Closes #6

## Key Changes
- Removed the `numba` package dependency and all associated JIT-compiled functions.
- Replaced the custom `batch_find_k_largest` function with the more efficient `torch.topk` for batch evaluation.
- Deleted the now-unused `find_k_largest` helper function.
- Deprecated the single-user `_evaluate` method, consolidating all logic into the batch evaluation method.